### PR TITLE
To use PHP-DI 6.0 with the Symfony Bridge, with Symfony 3.3, 3.4 et 4+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 composer.phar
 vendor/*
 .idea/*
+/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - 7.2
 
 matrix:
   include:
-    - php: 5.5
+    - php: 7.0
       env: dependencies=lowest
 
 before_script:
   - composer install -n
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
+
+script:
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         }
     },
     "require": {
-        "php": "~5.5|~7.0",
-        "php-di/php-di": "^5.0",
-        "symfony/dependency-injection": "^3.0",
-        "symfony/http-kernel": "^3.0",
-        "symfony/proxy-manager-bridge": "^3.0",
-        "symfony/config": "^3.0"
+        "php": "~7.0",
+        "php-di/php-di": "~6.0",
+        "symfony/dependency-injection": "^3.4",
+        "symfony/http-kernel": "^3.4",
+        "symfony/proxy-manager-bridge": "^3.4",
+        "symfony/config": "^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     "require": {
         "php": "~7.0",
         "php-di/php-di": "~6.0",
-        "symfony/dependency-injection": "^3.4",
-        "symfony/http-kernel": "^3.4",
-        "symfony/proxy-manager-bridge": "^3.4",
-        "symfony/config": "^3.4"
+        "symfony/dependency-injection": "~3.3",
+        "symfony/http-kernel": "~3.3",
+        "symfony/proxy-manager-bridge": "~3.3",
+        "symfony/config": "~3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     "require": {
         "php": "~7.0",
         "php-di/php-di": "~6.0",
-        "symfony/dependency-injection": "~3.3",
-        "symfony/http-kernel": "~3.3",
-        "symfony/proxy-manager-bridge": "~3.3",
-        "symfony/config": "~3.3"
+        "symfony/dependency-injection": "~3.3||~4.0",
+        "symfony/http-kernel": "~3.3||~4.0",
+        "symfony/proxy-manager-bridge": "~3.3||~4.0",
+        "symfony/config": "~3.3||~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -9,7 +9,6 @@
 
 namespace DI\Bridge\Symfony;
 
-use DI\ContainerBuilder as DiContainerBuilder;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Debug\DebugClassLoader;
 use Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass;
@@ -38,11 +37,11 @@ abstract class Kernel extends \Symfony\Component\HttpKernel\Kernel
     /**
      * Implement this method to configure PHP-DI.
      *
-     * @param DiContainerBuilder $builder
+     * @param \DI\ContainerBuilder $builder
      *
      * @return ContainerInterface
      */
-    abstract protected function buildPHPDIContainer(DiContainerBuilder $builder);
+    abstract protected function buildPHPDIContainer(\DI\ContainerBuilder $builder);
 
     protected function getContainerBaseClass()
     {
@@ -108,7 +107,7 @@ abstract class Kernel extends \Symfony\Component\HttpKernel\Kernel
     protected function getPHPDIContainer()
     {
         if ($this->phpdiContainer === null) {
-            $builder = new DiContainerBuilder();
+            $builder = new \DI\ContainerBuilder();
             $builder->wrapContainer($this->getContainer());
 
             $this->phpdiContainer = $this->buildPHPDIContainer($builder);

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -95,7 +95,7 @@ abstract class Kernel extends \Symfony\Component\HttpKernel\Kernel
 
     private function disableDebugClassLoader()
     {
-        if (!class_exists('Symfony\Component\Debug\DebugClassLoader')) {
+        if (!class_exists(DebugClassLoader::class)) {
             return;
         }
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -9,7 +9,8 @@
 
 namespace DI\Bridge\Symfony;
 
-use Interop\Container\ContainerInterface;
+use DI\ContainerBuilder as DiContainerBuilder;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Debug\DebugClassLoader;
 use Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -37,9 +38,11 @@ abstract class Kernel extends \Symfony\Component\HttpKernel\Kernel
     /**
      * Implement this method to configure PHP-DI.
      *
+     * @param DiContainerBuilder $builder
+     *
      * @return ContainerInterface
      */
-    abstract protected function buildPHPDIContainer(\DI\ContainerBuilder $builder);
+    abstract protected function buildPHPDIContainer(DiContainerBuilder $builder);
 
     protected function getContainerBaseClass()
     {
@@ -105,7 +108,7 @@ abstract class Kernel extends \Symfony\Component\HttpKernel\Kernel
     protected function getPHPDIContainer()
     {
         if ($this->phpdiContainer === null) {
-            $builder = new \DI\ContainerBuilder();
+            $builder = new DiContainerBuilder();
             $builder->wrapContainer($this->getContainer());
 
             $this->phpdiContainer = $this->buildPHPDIContainer($builder);

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -37,8 +37,6 @@ abstract class Kernel extends \Symfony\Component\HttpKernel\Kernel
     /**
      * Implement this method to configure PHP-DI.
      *
-     * @param \DI\ContainerBuilder $builder
-     *
      * @return ContainerInterface
      */
     abstract protected function buildPHPDIContainer(\DI\ContainerBuilder $builder);

--- a/src/SymfonyContainerBridge.php
+++ b/src/SymfonyContainerBridge.php
@@ -10,7 +10,7 @@
 namespace DI\Bridge\Symfony;
 
 use DI\NotFoundException;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container as SymfonyContainer;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class SymfonyContainerBridge extends SymfonyContainer implements SymfonyContainerInterface, ContainerInterface
+class SymfonyContainerBridge extends SymfonyContainer implements SymfonyContainerInterface
 {
     /**
      * @var ContainerInterface|null
@@ -87,7 +87,7 @@ class SymfonyContainerBridge extends SymfonyContainer implements SymfonyContaine
             return $entry;
         } catch (NotFoundException $e) {
             if ($invalidBehavior === self::EXCEPTION_ON_INVALID_REFERENCE) {
-                throw new ServiceNotFoundException($id);
+                throw new ServiceNotFoundException($id, null, $e);
             }
         }
 

--- a/src/SymfonyContainerBridge.php
+++ b/src/SymfonyContainerBridge.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class SymfonyContainerBridge extends SymfonyContainer implements SymfonyContainerInterface
+class SymfonyContainerBridge extends SymfonyContainer implements SymfonyContainerInterface, ContainerInterface
 {
     /**
      * @var ContainerInterface|null

--- a/tests/FunctionalTest/ContainerInteractionTest.php
+++ b/tests/FunctionalTest/ContainerInteractionTest.php
@@ -36,7 +36,7 @@ class ContainerInteractionTest extends AbstractFunctionalTest
 
         $phpdiContainer->set(
             'foo',
-            \DI\object(Class1::class)
+            \DI\create(Class1::class)
                 ->constructor(\DI\get('class2'))
         );
 
@@ -69,7 +69,9 @@ class ContainerInteractionTest extends AbstractFunctionalTest
         /** @var Container $phpdiContainer */
         $phpdiContainer = $container->getFallbackContainer();
 
-        $phpdiContainer->set('foo', \DI\get('class2'));
+        $ref = \DI\get('class2');
+        $ref->setName('foo');
+        $phpdiContainer->set('foo', $ref);
 
         $class2 = $container->get('foo');
 

--- a/tests/FunctionalTest/Fixtures/config/class1.yml
+++ b/tests/FunctionalTest/Fixtures/config/class1.yml
@@ -1,4 +1,5 @@
 services:
     class1:
         class: DI\Bridge\Symfony\Test\FunctionalTest\Fixtures\Class1
+        public: true
         arguments: [ '@DI\\Bridge\\Symfony\\Test\\FunctionalTest\\Fixtures\\Class2' ]

--- a/tests/FunctionalTest/Fixtures/config/class2.yml
+++ b/tests/FunctionalTest/Fixtures/config/class2.yml
@@ -1,3 +1,4 @@
 services:
     class2:
         class: DI\Bridge\Symfony\Test\FunctionalTest\Fixtures\Class2
+        public: true

--- a/tests/UnitTest/SymfonyContainerBridgeTest.php
+++ b/tests/UnitTest/SymfonyContainerBridgeTest.php
@@ -11,7 +11,8 @@ namespace DI\Bridge\Symfony\Test\UnitTest;
 
 use DI\Bridge\Symfony\SymfonyContainerBridge;
 use DI\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface as SfContainerInterface;
 
 class SymfonyContainerBridgeTest extends \PHPUnit_Framework_TestCase
 {
@@ -19,7 +20,7 @@ class SymfonyContainerBridgeTest extends \PHPUnit_Framework_TestCase
     {
         $wrapper = new SymfonyContainerBridge();
 
-        $fallback = $this->getMockForAbstractClass('Interop\Container\ContainerInterface');
+        $fallback = $this->getMockForAbstractClass(ContainerInterface::class);
         $fallback->expects($this->once())
             ->method('has')
             ->with('foo')
@@ -34,7 +35,7 @@ class SymfonyContainerBridgeTest extends \PHPUnit_Framework_TestCase
     {
         $wrapper = new SymfonyContainerBridge();
 
-        $fallback = $this->getMockForAbstractClass('Interop\Container\ContainerInterface');
+        $fallback = $this->getMockForAbstractClass(ContainerInterface::class);
         $fallback->expects($this->once())
             ->method('get')
             ->with('foo')
@@ -51,7 +52,7 @@ class SymfonyContainerBridgeTest extends \PHPUnit_Framework_TestCase
 
         $wrapper->setFallbackContainer(ContainerBuilder::buildDevContainer());
 
-        $this->assertNull($wrapper->get('foo', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+        $this->assertNull($wrapper->get('foo', SfContainerInterface::NULL_ON_INVALID_REFERENCE));
     }
 
     /**


### PR DESCRIPTION
Hi,
It's some patchs to allow use PHP-DI 6 with the bridge on Symfony 3.3, 3.4 and 4+.
This patch set the minimum required version of PHP to 7.0 (needed by PHP-DI 6).

I limited to Symfony 3.3 and higher because, from this version its container follows the PSR-11.

To allow alias from the PHP-DI container to the Symfony container, the Symfony service must be tagged as public, else it's not available with SF 4.0 and a deprecation notice is thrown with Symfony 3.4.

Have a nice day.
Richard.